### PR TITLE
Update non-pro menu label to "Upgrade to Pro"

### DIFF
--- a/Ditto/DittoListView.swift
+++ b/Ditto/DittoListView.swift
@@ -90,7 +90,7 @@ struct DittoListView: View {
                                 showSubscription = true
                             } label: {
                                 Label(
-                                    subscriptionManager.isProSubscriber ? "Manage Subscription" : "Enable iCloud Sync",
+                                    subscriptionManager.isProSubscriber ? "Manage Subscription" : "Upgrade to Pro",
                                     systemImage: subscriptionManager.isProSubscriber ? "checkmark.icloud" : "icloud"
                                 )
                             }


### PR DESCRIPTION
Changes the ... menu label shown to non-Pro subscribers from
"Enable iCloud Sync" to "Upgrade to Pro" to better reflect that
the action opens the subscription upsell.